### PR TITLE
Remove pip_base

### DIFF
--- a/include/pipes/base.hpp
+++ b/include/pipes/base.hpp
@@ -9,9 +9,7 @@
 #include <tuple>
 
 namespace pipes
-{
-    struct pipe_base {};
-    
+{    
     template<typename Pipeline>
     struct pipeline_proxy
     {

--- a/include/pipes/drop.hpp
+++ b/include/pipes/drop.hpp
@@ -6,7 +6,7 @@
 
 namespace pipes
 {
-    class drop : public pipe_base
+    class drop  
     {
     public:
         

--- a/include/pipes/drop_while.hpp
+++ b/include/pipes/drop_while.hpp
@@ -8,7 +8,7 @@
 namespace pipes
 {
     template<typename Predicate>
-    class drop_while_pipe : public pipe_base
+    class drop_while_pipe  
     {
     public:
         

--- a/include/pipes/filter.hpp
+++ b/include/pipes/filter.hpp
@@ -10,7 +10,7 @@
 namespace pipes
 {
     template<typename Predicate>
-    class filter_pipe : public pipe_base
+    class filter_pipe  
     {
     public:
         template<typename... Values, typename TailPipeline>

--- a/include/pipes/helpers/has_onReceive.hpp
+++ b/include/pipes/helpers/has_onReceive.hpp
@@ -3,16 +3,30 @@
 
 #include <type_traits>
 
+#include "pipes/base.hpp"
+
 namespace pipes
 {
 namespace detail
 {
 
+/*
+** Helper
+*/
 template<typename... Ts>
 struct sfinae_empty_helper {};
 
+/*
+** Dummies
+*/
+
 struct dummy_value_input_type {};
-struct dummy_tail_pipeline_type {};
+
+struct dummy_tail_pipeline_type: public pipeline_base<dummy_tail_pipeline_type> {};
+
+/*
+** Detect has a right onReceive
+*/
 
 template<typename T, typename _ = void>
 struct has_onReceive_method: std::false_type {};
@@ -31,7 +45,6 @@ struct has_onReceive_method
         void
     >
 > : public std::true_type {};
-
 
 }
 }

--- a/include/pipes/helpers/has_onReceive.hpp
+++ b/include/pipes/helpers/has_onReceive.hpp
@@ -1,0 +1,39 @@
+#ifndef HAS_ON_RECEIVE_HPP
+#define HAS_ON_RECEIVE_HPP
+
+#include <type_traits>
+
+namespace pipes
+{
+namespace detail
+{
+
+template<typename... Ts>
+struct sfinae_empty_helper {};
+
+struct dummy_value_input_type {};
+struct dummy_tail_pipeline_type {};
+
+template<typename T, typename _ = void>
+struct has_onReceive_method: std::false_type {};
+
+template<typename T>
+struct has_onReceive_method
+<
+    T,
+    std::conditional_t
+    <
+        false,
+        sfinae_empty_helper
+        <
+            decltype(std::declval<T>().template onReceive<dummy_value_input_type>(dummy_value_input_type{}, dummy_tail_pipeline_type{}))
+        >,
+        void
+    >
+> : public std::true_type {};
+
+
+}
+}
+
+#endif

--- a/include/pipes/impl/concepts.hpp
+++ b/include/pipes/impl/concepts.hpp
@@ -6,6 +6,7 @@
 
 #include "pipes/base.hpp"
 #include "pipes/helpers/detect.hpp"
+#include "pipes/helpers/has_onReceive.hpp"
 
 namespace pipes
 {
@@ -34,7 +35,8 @@ namespace pipes
             // definition of pipe
             
             template<typename Pipe>
-            using IsAPipe = std::enable_if_t<std::is_base_of<pipe_base, Pipe>::value, bool>;
+            //using IsAPipe = std::enable_if_t<std::is_base_of<pipe_base, Pipe>::value, bool>;
+            using IsAPipe = std::enable_if_t<std::is_base_of<std::true_type, pipes::detail::has_onReceive_method<std::remove_const_t<Pipe>>>::value && std::is_base_of<pipe_base, Pipe>::value, bool>;
             
             //definition of pipeline
             

--- a/include/pipes/impl/concepts.hpp
+++ b/include/pipes/impl/concepts.hpp
@@ -35,8 +35,7 @@ namespace pipes
             // definition of pipe
             
             template<typename Pipe>
-            //using IsAPipe = std::enable_if_t<std::is_base_of<pipe_base, Pipe>::value, bool>;
-            using IsAPipe = std::enable_if_t<std::is_base_of<std::true_type, pipes::detail::has_onReceive_method<std::remove_const_t<Pipe>>>::value && std::is_base_of<pipe_base, Pipe>::value, bool>;
+            using IsAPipe = std::enable_if_t<std::is_base_of<std::true_type, pipes::detail::has_onReceive_method<std::remove_const_t<Pipe>>>::value  && !std::is_base_of<pipeline_base<Pipe>, Pipe>::value, bool>;
             
             //definition of pipeline
             

--- a/include/pipes/impl/pipes_assembly.hpp
+++ b/include/pipes/impl/pipes_assembly.hpp
@@ -33,6 +33,13 @@ namespace pipes
             
             template<typename Pipe1_, typename Pipe2_>
             CompositePipe(Pipe1_&& pipe1, Pipe2_&& pipe2) : pipe1(FWD(pipe1)), pipe2(FWD(pipe2)){}
+
+            // Dummy method so it meets the IsAPipe requirements
+            template<typename Values, typename TailPipeline>
+            void onReceive(Values&&, TailPipeline&&)
+            {
+                // It is never supposed to be called!
+            }
         };
 
         template<typename HeadPipe, typename TailPipeline>

--- a/include/pipes/impl/pipes_assembly.hpp
+++ b/include/pipes/impl/pipes_assembly.hpp
@@ -26,7 +26,7 @@ namespace pipes
         };
 
         template<typename Pipe1, typename Pipe2>
-        struct CompositePipe : public pipe_base
+        struct CompositePipe  
         {
             Pipe1 pipe1;
             Pipe2 pipe2;

--- a/include/pipes/join.hpp
+++ b/include/pipes/join.hpp
@@ -8,7 +8,7 @@
 
 namespace pipes
 {
-    struct join_pipe : public pipe_base
+    struct join_pipe  
     {
         template<typename Collection, typename TailPipeline>
         void onReceive(Collection&& collection, TailPipeline&& tailPipeline)

--- a/include/pipes/take.hpp
+++ b/include/pipes/take.hpp
@@ -6,7 +6,7 @@
 
 namespace pipes
 {
-    class take : public pipe_base
+    class take  
     {
     public:
         template<typename... Values, typename TailPipeline>

--- a/include/pipes/take_while.hpp
+++ b/include/pipes/take_while.hpp
@@ -8,7 +8,7 @@
 namespace pipes
 {
     template<typename Predicate>
-    class take_while_pipe : public pipe_base
+    class take_while_pipe  
     {
     public:
         template<typename... Values, typename TailPipeline>

--- a/include/pipes/tee.hpp
+++ b/include/pipes/tee.hpp
@@ -11,7 +11,7 @@
 namespace pipes
 {
     template<typename TeeBranch>
-    class tee_pipe : public pipe_base
+    class tee_pipe  
     {
     public:
         template<typename Value, typename TailPipeline>

--- a/include/pipes/transform.hpp
+++ b/include/pipes/transform.hpp
@@ -14,7 +14,7 @@
 namespace pipes
 {
     template<typename Function>
-    class transform_pipe : public pipe_base
+    class transform_pipe  
     {
     public:
         template<typename... Values, typename TailPipeline>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,7 +25,8 @@ add_executable(pipes_test
     tee.cpp
     transform.cpp
     unzip.cpp
-    integration_tests.cpp)
+    integration_tests.cpp
+    has_on_receive.cpp)
 
 target_include_directories(pipes_test PRIVATE
                            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/tests/has_on_receive.cpp
+++ b/tests/has_on_receive.cpp
@@ -5,6 +5,7 @@
 #include "pipes/filter.hpp"
 #include "pipes/drop.hpp"
 #include "pipes/dev_null.hpp"
+#include "pipes/transform.hpp"
 
 struct dummy_without_onReceive{};
 
@@ -31,6 +32,12 @@ struct dummy_predicate
 {
     template <typename T>
     bool operator()(const T&&) { return true; }
+};
+
+struct dummy_transform_function
+{
+    template <typename T>
+    auto operator()(const T&& t) { return t; }
 };
 
 TEST_CASE("dummy does not have onReceive")
@@ -72,6 +79,12 @@ TEST_CASE("filter has onReceive")
 TEST_CASE("drop has onReceive")
 {
 	using sfinae_result = typename pipes::detail::has_onReceive_method<pipes::drop>;
+    REQUIRE((std::is_base_of<std::true_type, sfinae_result>::value));
+}
+
+TEST_CASE("transform has onReceive")
+{
+	using sfinae_result = typename pipes::detail::has_onReceive_method<pipes::transform_pipe<dummy_transform_function>>;
     REQUIRE((std::is_base_of<std::true_type, sfinae_result>::value));
 }
 

--- a/tests/has_on_receive.cpp
+++ b/tests/has_on_receive.cpp
@@ -1,0 +1,68 @@
+#include "catch.hpp"
+
+#include "pipes/helpers/has_onReceive.hpp"
+#include "pipes/join.hpp"
+#include "pipes/filter.hpp"
+
+struct dummy_without_onReceive{};
+
+struct dummy_with_wrong_onReceive
+{
+    template <typename T>
+    auto onReceive(T&&) { return 5;}
+};
+
+struct dummy_with_templated_onReceive
+{
+    template <typename T, typename U>
+    auto onReceive(T&&, U&&) { return 5;}
+};
+
+struct dummy_with_variadic_templated_onReceive
+{
+    template <typename ...T, typename U>
+    auto onReceive(T&&... t, U&& u) { return 5;}
+};
+
+
+struct dummy_predicate
+{
+    template <typename T>
+    bool operator()(const T&&) { return true; }
+};
+
+TEST_CASE("dummy does not have onReceive")
+{
+    using sfinae_result = typename pipes::detail::has_onReceive_method<dummy_without_onReceive>;
+    REQUIRE((std::is_base_of<std::true_type, sfinae_result>::value == false));
+}
+
+TEST_CASE("dummy wrong onReceive")
+{
+    using sfinae_result = typename pipes::detail::has_onReceive_method<dummy_with_wrong_onReceive>;
+    REQUIRE((std::is_base_of<std::true_type, sfinae_result>::value == false));
+}
+
+TEST_CASE("dummy has onReceive")
+{
+	using sfinae_result = typename pipes::detail::has_onReceive_method<dummy_with_templated_onReceive>;
+    REQUIRE((std::is_base_of<std::true_type, sfinae_result>::value));
+}
+
+TEST_CASE("join has onReceive")
+{
+	using sfinae_result = typename pipes::detail::has_onReceive_method<pipes::join_pipe>;
+    REQUIRE((std::is_base_of<std::true_type, sfinae_result>::value));
+}
+
+TEST_CASE("variadic has onReceive")
+{
+	using sfinae_result = typename pipes::detail::has_onReceive_method<dummy_with_variadic_templated_onReceive>;
+    REQUIRE((std::is_base_of<std::true_type, sfinae_result>::value));
+}
+
+TEST_CASE("filter has onReceive")
+{
+	using sfinae_result = typename pipes::detail::has_onReceive_method<pipes::filter_pipe<dummy_predicate>>;
+    REQUIRE((std::is_base_of<std::true_type, sfinae_result>::value));
+}

--- a/tests/has_on_receive.cpp
+++ b/tests/has_on_receive.cpp
@@ -3,6 +3,8 @@
 #include "pipes/helpers/has_onReceive.hpp"
 #include "pipes/join.hpp"
 #include "pipes/filter.hpp"
+#include "pipes/drop.hpp"
+#include "pipes/dev_null.hpp"
 
 struct dummy_without_onReceive{};
 
@@ -49,15 +51,15 @@ TEST_CASE("dummy has onReceive")
     REQUIRE((std::is_base_of<std::true_type, sfinae_result>::value));
 }
 
-TEST_CASE("join has onReceive")
-{
-	using sfinae_result = typename pipes::detail::has_onReceive_method<pipes::join_pipe>;
-    REQUIRE((std::is_base_of<std::true_type, sfinae_result>::value));
-}
-
 TEST_CASE("variadic has onReceive")
 {
 	using sfinae_result = typename pipes::detail::has_onReceive_method<dummy_with_variadic_templated_onReceive>;
+    REQUIRE((std::is_base_of<std::true_type, sfinae_result>::value));
+}
+
+TEST_CASE("join has onReceive")
+{
+	using sfinae_result = typename pipes::detail::has_onReceive_method<pipes::join_pipe>;
     REQUIRE((std::is_base_of<std::true_type, sfinae_result>::value));
 }
 
@@ -65,4 +67,16 @@ TEST_CASE("filter has onReceive")
 {
 	using sfinae_result = typename pipes::detail::has_onReceive_method<pipes::filter_pipe<dummy_predicate>>;
     REQUIRE((std::is_base_of<std::true_type, sfinae_result>::value));
+}
+
+TEST_CASE("drop has onReceive")
+{
+	using sfinae_result = typename pipes::detail::has_onReceive_method<pipes::drop>;
+    REQUIRE((std::is_base_of<std::true_type, sfinae_result>::value));
+}
+
+TEST_CASE("dev_null wrong onReceive")
+{
+	using sfinae_result = typename pipes::detail::has_onReceive_method<pipes::dev_null>;
+    REQUIRE((std::is_base_of<std::true_type, sfinae_result>::value == false));
 }

--- a/tests/has_on_receive.cpp
+++ b/tests/has_on_receive.cpp
@@ -1,6 +1,9 @@
 #include "catch.hpp"
 
 #include "pipes/helpers/has_onReceive.hpp"
+
+#include "pipes/impl/concepts.hpp"
+
 #include "pipes/join.hpp"
 #include "pipes/filter.hpp"
 #include "pipes/drop.hpp"
@@ -17,7 +20,7 @@ struct dummy_with_wrong_onReceive
 
 struct dummy_with_templated_onReceive
 {
-    template <typename T, typename U>
+    template <typename T, typename U, pipes::detail::IsAPipeline<U> = 0>
     auto onReceive(T&&, U&&) { return 5;}
 };
 


### PR DESCRIPTION
I managed to detect if it is a pipe without using the tag **pipe_base**.

To do so, it detects if the class has a method named **onReceive** which can have 2 arguments or more.
But there are two drawbacks:
- **CompositePipe** has now a useless **onReceive** method to meet the **IsAPipe** requirements
- Because **generic_pipeline** has a method onReceive with variadic arguments it also meets the **IsAPipe** requirements so in **IsAPipe** it also check that the pipe does not inherit from **pipeline_base**.

The first drawback does not seems to be a real probrem. The second bothers me, I tried to check on **has_onReceive_method** if the last argument must meet **IsAPipeline** requirements but for now I failed.

I will be happy to have a review on it even if you don't want to accept the pull request.