### PR TITLE
Add the NEW tap pipe

### DIFF
--- a/include/pipes/tap.hpp
+++ b/include/pipes/tap.hpp
@@ -1,0 +1,37 @@
+#ifndef PIPES_TAP_HPP
+#define PIPES_TAP_HPP
+
+#include "pipes/operator.hpp"
+
+#include "pipes/base.hpp"
+#include "pipes/helpers/assignable.hpp"
+#include "pipes/helpers/FWD.hpp"
+
+namespace pipes
+{
+    
+    template<typename Function>
+    class tap_pipe : public pipe_base
+    {
+    public:
+        template<typename Value, typename TailPipeline>
+        void onReceive(Value&& value, TailPipeline&& tailPipeline)
+        {
+            function_(FWD(value));
+            send(FWD(value), tailPipeline);
+        }
+        
+        explicit tap_pipe(Function function) : function_(function) {}
+        
+    private:
+        detail::assignable<Function> function_;
+    };
+    
+    template <typename Function>
+    tap_pipe<Function> tap(Function function) {
+        return tap_pipe<Function>(function);
+    }
+    
+} // namespace pipes
+
+#endif /* PIPES_TAP_HPP */

--- a/include/pipes/tap.hpp
+++ b/include/pipes/tap.hpp
@@ -1,6 +1,8 @@
 #ifndef PIPES_TAP_HPP
 #define PIPES_TAP_HPP
 
+#include <type_traits>
+
 #include "pipes/operator.hpp"
 
 #include "pipes/base.hpp"
@@ -20,6 +22,12 @@ namespace pipes
             function_(FWD(value));
             send(FWD(value), tailPipeline);
         }
+
+        template<typename Value>
+        void onReceive(Value&& value)
+        {
+            function_(FWD(value));
+        }
         
         explicit tap_pipe(Function function) : function_(function) {}
         
@@ -28,8 +36,8 @@ namespace pipes
     };
     
     template <typename Function>
-    tap_pipe<Function> tap(Function function) {
-        return tap_pipe<Function>(function);
+    tap_pipe<std::decay_t<Function>> tap(Function&& function) {
+        return tap_pipe<std::decay_t<Function>>(FWD(function));
     }
     
 } // namespace pipes

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(pipes_test
     switch.cpp
     take.cpp
     take_while.cpp
+    tap.cpp
     tee.cpp
     transform.cpp
     unzip.cpp

--- a/tests/tap.cpp
+++ b/tests/tap.cpp
@@ -1,0 +1,21 @@
+#include "catch.hpp"
+#include "pipes/operator.hpp"
+#include "pipes/push_back.hpp"
+#include "pipes/tap.hpp"
+#include "pipes/transform.hpp"
+
+#include <algorithm>
+#include <vector>
+
+TEST_CASE("tap")
+{
+    std::vector<int> input = {1, 2, 3, 4, 5, 6, 7 ,8, 9, 10};
+    std::vector<int> expected = {2, 4, 6, 8, 10, 12, 14, 16, 18, 20};
+    std::vector<int> results;
+
+    input >>= pipes::transform([](auto const& x) { return x * 2; })
+          >>= pipes::tap([&expected, i = uint{0}](auto const& x) mutable { REQUIRE(x == expected[i++]); })
+          >>= pipes::push_back(results);
+    
+    REQUIRE(results == expected);
+}

--- a/tests/tap.cpp
+++ b/tests/tap.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <vector>
+#include <list>
 
 TEST_CASE("tap")
 {
@@ -18,4 +19,35 @@ TEST_CASE("tap")
           >>= pipes::push_back(results);
     
     REQUIRE(results == expected);
+}
+
+TEST_CASE("tap operator=")
+{
+    using range_type = std::list<int>;
+
+    class FrontInserter
+    {
+    public:
+        FrontInserter(range_type& range) : range_(range) {}
+
+        void operator()(range_type::value_type value) const 
+        {
+            range_.push_front(value);
+        } 
+    private:
+        range_type& range_;
+    };
+
+    range_type results1, results2, results3, results4;
+    
+    auto tap1 = pipes::tap(FrontInserter(results1)) >>= pipes::push_back(results2);
+    auto tap2 = pipes::tap(FrontInserter(results3)) >>= pipes::push_back(results4);
+    
+    tap2 = tap1;
+    pipes::send(0, tap2);
+    
+    REQUIRE(results1.size() == 1);
+    REQUIRE(results2.size() == 1);
+    REQUIRE(results3.size() == 0);
+    REQUIRE(results4.size() == 0);
 }


### PR DESCRIPTION
The **tap** pipe is highly inspired by [RxJS tap](https://rxjs-dev.firebaseapp.com/api/operators/tap) operator.

Basically the tap pipe is akin to custom pipeline but forward every received values to the next pipe/pipeline.

@joboccara Maybe the custom pipeline should be deleted in favor to the tap pipe - same responsibility but not the same expressiveness. 