### PR TITLE
NEW: repeat pipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@
 .DS_Store
 build/
 install/
-/cmake-build-debug/
-/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .DS_Store
 build/
 install/
+/cmake-build-debug/
+/.idea/

--- a/include/pipes/pipes.hpp
+++ b/include/pipes/pipes.hpp
@@ -18,6 +18,7 @@
 #include "pipes/partition.hpp"
 #include "pipes/push_back.hpp"
 #include "pipes/read_in_stream.hpp"
+#include "pipes/repeat.hpp"
 #include "pipes/set_aggregator.hpp"
 #include "pipes/sorted_inserter.hpp"
 #include "pipes/switch.hpp"

--- a/include/pipes/repeat.hpp
+++ b/include/pipes/repeat.hpp
@@ -16,16 +16,16 @@ public:
   template<typename Value, typename TailPipeline>
   void onReceive(Value&& value, TailPipeline&& tailPipeline)
   {
-    for (uint64_t i = 0; i < n_.get(); ++i) {
+    for (uint64_t i = 0; i < n_; ++i) {
       send(value, tailPipeline);
     }
     send(FWD(value), tailPipeline);
   }
 
-  explicit repeat(uint64_t n) : n_(n) {}
+  explicit repeat(size_t n) : n_(n) {}
 
 private:
-  detail::assignable<uint64_t> n_;
+  size_t n_;
 };
 
 } // namespace pipes

--- a/include/pipes/repeat.hpp
+++ b/include/pipes/repeat.hpp
@@ -1,0 +1,32 @@
+#ifndef PIPES_REPEAT_HPP
+#define PIPES_REPEAT_HPP
+
+#include "pipes/operator.hpp"
+
+#include "pipes/base.hpp"
+#include "pipes/helpers/assignable.hpp"
+#include "pipes/helpers/FWD.hpp"
+
+namespace pipes
+{
+
+class repeat : public pipe_base
+{
+public:
+  template<typename Value, typename TailPipeline>
+  void onReceive(Value&& value, TailPipeline&& tailPipeline)
+  {
+    for (uint64_t i = 0; i <= n_.get(); ++i) {
+      send(FWD(value), tailPipeline);
+    }
+  }
+
+  explicit repeat(uint64_t n) : n_(n) {}
+
+private:
+  detail::assignable<uint64_t> n_;
+};
+
+} // namespace pipes
+
+#endif /* PIPES_REPEAT_HPP */

--- a/include/pipes/repeat.hpp
+++ b/include/pipes/repeat.hpp
@@ -16,9 +16,10 @@ public:
   template<typename Value, typename TailPipeline>
   void onReceive(Value&& value, TailPipeline&& tailPipeline)
   {
-    for (uint64_t i = 0; i <= n_.get(); ++i) {
-      send(FWD(value), tailPipeline);
+    for (uint64_t i = 0; i < n_.get(); ++i) {
+      send(value, tailPipeline);
     }
+    send(FWD(value), tailPipeline);
   }
 
   explicit repeat(uint64_t n) : n_(n) {}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(pipes_test
     mux.cpp
     override.cpp
     partition.cpp
+    repeat.cpp
     streams.cpp
     switch.cpp
     take.cpp

--- a/tests/repeat.cpp
+++ b/tests/repeat.cpp
@@ -1,0 +1,17 @@
+#include "catch.hpp"
+#include "pipes/pipes.hpp"
+
+#include <vector>
+
+TEST_CASE("repeat sends n consecutive copies of each element to the next pipe")
+{
+  auto const input = std::vector<int>{1, 2, 3, 4, 5};
+  auto const expected = std::vector<int>{1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5};
+
+  auto results = std::vector<int>{};
+
+  input >>= pipes::repeat(2)
+        >>= pipes::push_back(results);
+
+  REQUIRE(results == expected);
+}


### PR DESCRIPTION
Added a repeat pipe which returns subsequent copies of the input pipe's elements, e.g, {1,2} => {1,1,2, 2}. It may be simple, but I wanted to play around with your neat pipes library ;)

FYI: I'm also working on a batch pipe, returning fixed sized batches of consecutive input pipe elements up to the last batch which may contain less than the specified batch size (i.e., the remaining elements).