### PR TITLE
Added step pipe

### DIFF
--- a/include/pipes/pipes.hpp
+++ b/include/pipes/pipes.hpp
@@ -20,6 +20,7 @@
 #include "pipes/read_in_stream.hpp"
 #include "pipes/set_aggregator.hpp"
 #include "pipes/sorted_inserter.hpp"
+#include "pipes/step.hpp"
 #include "pipes/switch.hpp"
 #include "pipes/take.hpp"
 #include "pipes/take_while.hpp"

--- a/include/pipes/step.hpp
+++ b/include/pipes/step.hpp
@@ -1,0 +1,35 @@
+#ifndef PIPES_STEP_HPP
+#define PIPES_STEP_HPP
+
+#include "pipes/base.hpp"
+#include "pipes/helpers/FWD.hpp"
+
+namespace pipes
+{
+    class step : public pipe_base
+    {
+    public:
+        
+        template<typename... Values, typename TailPipeline>
+        void onReceive(Values&&... values, TailPipeline&& tailPipeline)
+        {
+            if (nbSinceLastStep_ == 0)
+            {
+                send(FWD(values)..., FWD(tailPipeline));
+            }
+            nbSinceLastStep_++;
+
+            if( nbSinceLastStep_ == stepSize_ ) {
+                nbSinceLastStep_ = 0;
+            }
+        }
+
+        explicit step(size_t stepSize) : stepSize_{stepSize}, nbSinceLastStep_{0} {}
+        
+    private:
+        const size_t stepSize_;
+        size_t nbSinceLastStep_;
+    };
+} // namespace pipes
+
+#endif /* PIPES_STEP_HPP */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(pipes_test
     mux.cpp
     override.cpp
     partition.cpp
+	step.cpp
     streams.cpp
     switch.cpp
     take.cpp

--- a/tests/step.cpp
+++ b/tests/step.cpp
@@ -1,0 +1,86 @@
+#include "catch.hpp"
+#include "pipes/pipes.hpp"
+
+TEST_CASE("step passes every N th element starting from 0")
+{
+    auto const input = std::vector<int>{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    auto const expected = std::vector<int>{ 1, 4, 7, 10 };
+    
+    auto result = std::vector<int>{};
+    
+    input >>= pipes::step(3)
+          >>= pipes::push_back(result);
+    
+    REQUIRE(result == expected);
+}
+
+TEST_CASE("step passes all elements if N is 1")
+{
+    auto const input = std::vector<int>{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    auto const expected = std::vector<int>{ 2, 4, 6, 8, 10 };
+    
+    auto result = std::vector<int>{};
+    
+    input >>= pipes::filter([](int i){ return i % 2 == 0; })
+          >>= pipes::step(1)
+          >>= pipes::push_back(result);
+    
+    REQUIRE(result == expected);
+}
+
+TEST_CASE("step passes only first element if N is greater than or equal to size of incoming input")
+{
+    auto const input = std::vector<int>{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    auto const expected = std::vector<int>{ 2 };
+    
+    auto result = std::vector<int>{};
+    
+    input >>= pipes::filter([](int i){ return i % 2 == 0; })
+          >>= pipes::step(10)
+          >>= pipes::push_back(result);
+    
+    REQUIRE(result == expected);
+}
+
+TEST_CASE("step passes only first element if N is zero")
+{
+    auto const input = std::vector<int>{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    auto const expected = std::vector<int>{ 1 };
+    
+    auto result = std::vector<int>{};
+    
+    input >>= pipes::step(0)
+          >>= pipes::push_back(result);
+    
+    REQUIRE(result == expected);
+}
+
+TEST_CASE("step steps over elements coming from several collections")
+{
+    auto const input1 = std::vector<int>{ 1, 2, 3, 4, 5};
+    auto const input2 = std::vector<int>{ 10, 20, 30, 40, 50};
+
+    auto const expected = std::vector<int>{ 11, 33, 55 };
+    
+    auto result = std::vector<int>{};
+    
+    pipes::mux(input1, input2)
+        >>= pipes::step(2)
+        >>= pipes::transform([](int a, int b){ return a + b; })
+        >>= pipes::push_back(result);
+    
+    REQUIRE(result == expected);
+}
+
+TEST_CASE("step doesn't send anything on if the input is empty")
+{
+    auto const input = std::vector<int>{ };
+    auto const expected = std::vector<int>{ };
+    
+    auto result = std::vector<int>{};
+    
+    input >>= pipes::step(10)
+          >>= pipes::push_back(result);
+    
+    REQUIRE(result == expected);
+}


### PR DESCRIPTION
It operates like python's list slicing
```python
numbers[first : last : step]
```
This only takes the `step`  into consideration and thus as the parameter.

It passes only the `step`th or the Nth element including the first element
```
{1, 2, 3, 4, 5, 6} >= step(3)  --> {1, 4}
```

Difference from pythonic step is that it accepts 0 as a valid step and in that case would only print the first element

I made this using `pipes::drop` files, please do report if any residue found.