### PR TITLE
Fixes for compilation errors on GCC 5 / 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,16 @@ matrix:
         apt:
           packages:
             - g++-7
+    - env: CXX=g++-6 CC=gcc-6
+      addons:
+        apt:
+          packages:
+            - g++-6
+    - env: CXX=g++-5 CC=gcc-5
+      addons:
+        apt:
+          packages:
+            - g++-5
     - env: CXX=clang++-9 CC=clang-9
       addons:
         apt:

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -13,24 +13,24 @@
 TEST_CASE("Mix of various pipes")
 {
     std::vector<int> numbers = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    
+
     std::vector<int> expectedOutput1 = {6, 12, 18};
     std::vector<int> expectedOutput2 = {2, 4};
     std::vector<int> expectedOutput3 = {2, 10};
     std::vector<int> expectedOutput4 = {1, 5, 7};
     std::vector<char> expectedOutput5 = {'A', 'A', 'A'};
-    
+
     std::vector<int> output1;
     std::vector<int> output2;
     std::vector<int> output3;
     std::vector<int> output4;
     std::vector<char> output5;
-    
+
     auto const times2 = pipes::transform([](int i) { return i*2; });
     auto const divideBy2 = pipes::transform([](int i) { return i/2; });
     auto const pairUpWithA = pipes::transform([](int i) { return std::make_pair(i, 'A'); });
-    
-    
+
+
     std::copy(begin(numbers), end(numbers), pipes::switch_(pipes::case_( [](int n){ return n % 3 == 0; } ) >>= times2 >>= pipes::push_back(output1),
                                                            pipes::case_( [](int n){ return n % 2 == 0; } ) >>= divideBy2 >>= pipes::partition([](int n){ return n % 2 == 0; },
                                                                                                                                              pipes::push_back(output2),
@@ -41,7 +41,7 @@ TEST_CASE("Mix of various pipes")
                                                                                                                                             pipes::push_back(output5)
                                                                                                                                            )
                                                                                                                       ));
-    
+
     REQUIRE(output1 == expectedOutput1);
     REQUIRE(output2 == expectedOutput2);
     REQUIRE(output3 == expectedOutput3);
@@ -56,7 +56,7 @@ TEST_CASE("Compatibility with STL algorithms")
     std::vector<int> results;
 
     std::copy(begin(input), end(input), pipes::transform([](int i){ return i * 2; }) >>= pipes::push_back(results));
-    
+
     REQUIRE(expected == results);
 }
 
@@ -64,12 +64,12 @@ TEST_CASE("Transform and filter")
 {
     std::vector<int> input = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     std::vector<int> expected = {8, 16, 24, 32, 40};
-    
+
     auto const isEven = [](int n){ return n % 2 == 0; };
     auto const times2 = [](int n){ return n * 2; };
 
     std::vector<int> results;
-    
+
     SECTION("chaining with >>=")
     {
         input >>= pipes::filter(isEven)
@@ -84,14 +84,14 @@ TEST_CASE("transform then filter calls the transform function only once per elem
 {
     auto const input = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     auto const expected = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    
+
     auto results = std::vector<int>{};
     auto output = std::vector<int>{};
-    
+
     input >>= pipes::transform([&results](int i){ results.push_back(i); return i * 2; })
           >>= pipes::filter([](int i){ return i % 3 == 0; })
           >>= pipes::push_back(output);
-    
+
     REQUIRE(results == expected);
 }
 
@@ -99,12 +99,12 @@ TEST_CASE("Sequence of output iterators, no algorithms")
 {
     std::vector<int> numbers = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     std::vector<int> expected = {4, 8, 12, 16, 20, 24, 28, 32, 36, 40};
-    
+
     auto const times2 = pipes::transform([](int n){ return n * 2; });
     std::vector<int> results;
-    
+
     numbers >>= times2 >>= times2 >>= pipes::push_back(results);
-    
+
     REQUIRE(results == expected);
 }
 
@@ -112,12 +112,12 @@ TEST_CASE("Sequence of output iterators, no algorithms, with pipes")
 {
     std::vector<int> numbers = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     std::vector<int> expected = {4, 8, 12, 16, 20, 24, 28, 32, 36, 40};
-    
+
     auto const times2 = [](int n){ return n * 2; };
     std::vector<int> results;
-    
+
     numbers >>= pipes::transform(times2) >>= pipes::transform(times2) >>= pipes::push_back(results);
-    
+
     REQUIRE(results == expected);
 }
 
@@ -130,12 +130,12 @@ TEST_CASE("Sequence of input ranges and output iterators, with pipes")
 {
     std::vector<int> numbers = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     std::vector<int> expected = {4, 8, 12, 16, 20, 24, 28, 32, 36, 40};
-    
+
     auto const times2 = [](int n){ return n * 2; };
     std::vector<int> results;
-    
+
     numbers | numbers | numbers >>= pipes::transform(times2) >>= pipes::transform(times2) >>= pipes::push_back(results);
-    
+
     REQUIRE(results == expected);
 }
 
@@ -147,9 +147,18 @@ namespace MyCollectionNamespace
     {
         std::vector<int> data_;
     };
-    
-    auto begin(MyCollection const& myCollection) { return begin(myCollection.data_); }
-    auto end(MyCollection const& myCollection) { return end(myCollection.data_); }
+
+    auto begin(MyCollection const& myCollection)
+    {
+        using std::begin;
+        return begin(myCollection.data_);
+    }
+
+    auto end(MyCollection const& myCollection)
+    {
+        using std::end;
+        return end(myCollection.data_);
+    }
 }
 }
 
@@ -160,7 +169,7 @@ TEST_CASE("Reading from a collection with ADL begin and end")
     auto results = std::vector<int>{};
 
     input >>= pipes::transform([](int i){ return i *2; }) >>= pipes::push_back(results);
-    
+
     REQUIRE(results == expected);
 }
 
@@ -168,19 +177,19 @@ TEST_CASE("Aggregation of pipes into reusable components")
 {
     auto const input = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     auto results = std::vector<int>{};
-    
+
     SECTION("End of pipeline aggregated")
     {
         auto const expected = std::vector<int>{4, 8, 12, 16, 20};
         auto pipeline = pipes::filter([](int i) { return i % 2 == 0; })
                     >>= pipes::transform([](int i){ return i * 2;})
                     >>= pipes::push_back(results);
-        
+
         input >>= pipeline;
-        
+
         REQUIRE(results == expected);
     }
-    
+
     SECTION("Middle of pipeline aggregated")
     {
         SECTION("Composite of simple pipes")
@@ -188,51 +197,51 @@ TEST_CASE("Aggregation of pipes into reusable components")
             auto const expected = std::vector<int>{4, 8, 12, 16, 20};
             auto pipeline = pipes::filter([](int i) { return i % 2 == 0; })
                         >>= pipes::transform([](int i){ return i * 2;});
-            
+
             input >>= pipeline >>= pipes::push_back(results);
-            
+
             REQUIRE(results == expected);
         }
-        
+
         SECTION("Composite + pipe")
         {
             auto const expected = std::vector<int>{8, 16, 24, 32, 40};
 
             auto pipeline = pipes::filter([](int i) { return i % 2 == 0; })
                         >>= pipes::transform([](int i){ return i * 2;});
-            
+
             auto pipeline2 = pipeline >>= pipes::transform([](int i){ return i * 2;});
-            
+
             input >>= pipeline2 >>= pipes::push_back(results);
 
             REQUIRE(results == expected);
         }
-        
+
         SECTION("pipe + composite")
         {
             auto const expected = std::vector<int>{4, 8, 12, 16, 20, 24, 28, 32, 36, 40};
-            
+
             auto pipeline = pipes::filter([](int i) { return i % 2 == 0; })
                         >>= pipes::transform([](int i){ return i * 2;});
-            
+
             auto pipeline2 = pipes::transform([](int i){ return i * 2;}) >>= pipeline;
-            
+
             input >>= pipeline2 >>= pipes::push_back(results);
-            
+
             REQUIRE(results == expected);
         }
-        
+
         SECTION("composite + composite")
         {
             auto const expected = std::vector<int>{8, 16, 24, 32, 40};
-            
+
             auto pipeline = pipes::filter([](int i) { return i % 2 == 0; })
                         >>= pipes::transform([](int i){ return i * 2;});
-            
+
             auto pipeline2 = pipeline >>= pipeline;
-            
+
             input >>= pipeline2 >>= pipes::push_back(results);
-            
+
             REQUIRE(results == expected);
         }
     }

--- a/tests/override.cpp
+++ b/tests/override.cpp
@@ -8,10 +8,10 @@ TEST_CASE("Override existing contents on STL containers")
 {
     auto input = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     std::vector<int> expected = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    
+
     std::vector<int> results = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     input >>= pipes::override(results);
-    
+
     REQUIRE(results == expected);
 }
 
@@ -24,8 +24,12 @@ namespace
             std::vector<int> data_;
             explicit MyCollection(std::vector<int> data) : data_(std::move(data)) {}
         };
-        
-        auto begin(MyCollection& myCollection) { return begin(myCollection.data_); }
+
+        auto begin(MyCollection& myCollection)
+        {
+            using std::begin;
+            return begin(myCollection.data_);
+        }
     }
 }
 
@@ -33,10 +37,10 @@ TEST_CASE("Override existing contents on collections with ADL begin")
 {
     auto input = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     std::vector<int> expected = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    
+
     auto results = MyCollectionNamespace::MyCollection(std::vector<int>{0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
     input >>= pipes::override(results);
-    
+
     REQUIRE(results.data_ == expected);
 }
 
@@ -44,9 +48,9 @@ TEST_CASE("Override contents of a C array")
 {
     auto input = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     std::vector<int> expected = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    
+
     int results[10] = {};
     input >>= pipes::override(results);
-    
+
     REQUIRE(std::equal(std::begin(results), std::end(results), begin(expected), end(expected)));
 }

--- a/tests/unzip.cpp
+++ b/tests/unzip.cpp
@@ -12,15 +12,15 @@
 
 TEST_CASE("unzip breaks tuples down to containers")
 {
-    std::vector<std::tuple<int, int, int>> lines = { {1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12} };
+    std::vector<std::tuple<int, int, int>> lines = { std::make_tuple(1, 2, 3), std::make_tuple(4, 5, 6), std::make_tuple(7, 8, 9), std::make_tuple(10, 11, 12) };
     std::vector<int> column1, column2, column3;
-    
+
     std::copy(begin(lines), end(lines), pipes::unzip(pipes::push_back(column1), pipes::push_back(column2), pipes::push_back(column3)));
-    
+
     std::vector<int> expectedColumn1 = {1, 4, 7, 10};
     std::vector<int> expectedColumn2 = {2, 5, 8, 11};
     std::vector<int> expectedColumn3 = {3, 6, 9, 12};
-    
+
     REQUIRE(column1 == expectedColumn1);
     REQUIRE(column2 == expectedColumn2);
     REQUIRE(column3 == expectedColumn3);
@@ -34,9 +34,9 @@ TEST_CASE("unzip breaks pairs down to two containers")
 
     std::vector<int> keys;
     std::vector<std::string> values;
-    
+
     std::copy(begin(entries), end(entries), pipes::unzip(pipes::push_back(keys), pipes::push_back(values)));
-    
+
     REQUIRE(keys == expectedKeys);
     REQUIRE(values == expectedValues);
 }
@@ -52,17 +52,17 @@ TEST_CASE("unzip's iterator category should be std::output_iterator_tag")
 
 TEST_CASE("unzip can override existing contents")
 {
-    std::vector<std::tuple<int, int, int>> lines = { {1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12} };
+    std::vector<std::tuple<int, int, int>> lines = { std::make_tuple(1, 2, 3), std::make_tuple(4, 5, 6), std::make_tuple(7, 8, 9), std::make_tuple(10, 11, 12) };
     std::vector<int> column1 = {0, 0, 0, 0, 0};
     std::vector<int> column2 = {0, 0, 0, 0, 0};
     std::vector<int> column3 = {0, 0, 0, 0, 0};
-    
+
     std::copy(begin(lines), end(lines), pipes::unzip(pipes::override(column1), pipes::override(column2), pipes::override(column3)));
-    
+
     std::vector<int> expectedColumn1 = {1, 4, 7, 10, 0};
     std::vector<int> expectedColumn2 = {2, 5, 8, 11, 0};
     std::vector<int> expectedColumn3 = {3, 6, 9, 12, 0};
-    
+
     REQUIRE(column1 == expectedColumn1);
     REQUIRE(column2 == expectedColumn2);
     REQUIRE(column3 == expectedColumn3);
@@ -80,16 +80,16 @@ TEST_CASE("unzip + transform")
     std::map<int, std::string> entries = { {1, "one"}, {2, "two"}, {3, "three"}, {4, "four"}, {5, "five"} };
     std::vector<int> expectedKeys = {1, 2, 3, 4, 5};
     std::vector<std::string> expectedValues = {"ONE", "TWO", "THREE", "FOUR", "FIVE"};
-    
+
     std::vector<int> keys;
     std::vector<std::string> values;
-    
+
     auto const toUpper = pipes::transform(toUpperString);
-    
+
     std::copy(begin(entries), end(entries),
               pipes::unzip(pipes::push_back(keys),
                            toUpper >>= pipes::push_back(values)));
-    
+
     REQUIRE(keys == expectedKeys);
     REQUIRE(values == expectedValues);
 }
@@ -102,7 +102,7 @@ TEST_CASE("unzip operator=")
     auto results4 = std::vector<std::string>{};
     auto pipeline1 = pipes::unzip(pipes::push_back(results1), pipes::push_back(results2));
     auto pipeline2 = pipes::unzip(pipes::push_back(results3), pipes::push_back(results4));
-    
+
     pipeline2 = pipeline1;
     send(std::make_pair(0, "zero"), pipeline2);
     REQUIRE(results1.size() == 1);


### PR DESCRIPTION
Fixes for compilation errors on GCC 5 and 6:

#### use of auto before deduction of auto

From the error it seems that the implementation of `begin()` and `end()` can't find appropriate functions for the `std::vector`:

```
[…]/pipes/tests/override.cpp:28:57: error: use of ‘auto {anonymous}::MyCollectionNamespace::begin({anonymous}::MyCollectionNamespace::MyCollection&)’ before deduction of ‘auto’
         auto begin(MyCollection& myCollection) { return begin(myCollection.data_); }
                                                         ^~~~~
```

#### converting from initializer list would use explicit constructor

This fails on GCC 5 only. I guess later versions have fixed the defect report _N4387_.

```
[…]/pipes/tests/unzip.cpp:15:100: error: converting to ‘std::tuple<int, int, int>’ from initializer list would use explicit constructor ‘constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {int, int, int}; <template-parameter-2-2> = void; _Elements = {int, int, int}]’
 uple<int, int, int>> lines = { {1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12} };
                                                                              ^
```

#### GCC 5 and 6 CI builds

I have added CI builds to cover both compiler versions.