### PR TITLE
Compile fix for MSVC compiler

### DIFF
--- a/tests/streams.cpp
+++ b/tests/streams.cpp
@@ -2,15 +2,14 @@
 #include "pipes/pipes.hpp"
 
 #include <algorithm>
+#include <cctype>
 #include <iostream>
-#include <locale>
 #include <sstream>
 
 std::string toUpper(std::string const& s)
 {
     std::string result(s.size(), '_');
-    std::locale loc;
-    std::transform(begin(s), end(s), begin(result), [&loc](char c){ return static_cast<char>(std::toupper(c, loc)); });
+    std::transform(begin(s), end(s), begin(result), [](char c){ return static_cast<char>(std::toupper(c)); });
     return result;
 }
 

--- a/tests/streams.cpp
+++ b/tests/streams.cpp
@@ -3,12 +3,14 @@
 
 #include <algorithm>
 #include <iostream>
+#include <locale>
 #include <sstream>
 
 std::string toUpper(std::string const& s)
 {
     std::string result(s.size(), '_');
-    std::transform(begin(s), end(s), begin(result), [](char c){ return static_cast<char>(std::toupper(c)); });
+    std::locale loc;
+    std::transform(begin(s), end(s), begin(result), [&loc](char c){ return static_cast<char>(std::toupper(c, loc)); });
     return result;
 }
 

--- a/tests/unzip.cpp
+++ b/tests/unzip.cpp
@@ -5,6 +5,7 @@
 #include "pipes/unzip.hpp"
 
 #include <algorithm>
+#include <locale>
 #include <map>
 #include <string>
 #include <utility>
@@ -70,7 +71,8 @@ TEST_CASE("unzip can override existing contents")
 std::string toUpperString(std::string const& s)
 {
     std::string upperString;
-    std::transform(begin(s), end(s), pipes::push_back(upperString), [](char c){ return static_cast<char>(std::toupper(c)); });
+    std::locale loc;
+    std::transform(begin(s), end(s), pipes::push_back(upperString), [&loc](char c){ return static_cast<char>(std::toupper(c, loc)); });
     return upperString;
 }
 

--- a/tests/unzip.cpp
+++ b/tests/unzip.cpp
@@ -5,7 +5,7 @@
 #include "pipes/unzip.hpp"
 
 #include <algorithm>
-#include <locale>
+#include <cctype>
 #include <map>
 #include <string>
 #include <utility>
@@ -71,8 +71,7 @@ TEST_CASE("unzip can override existing contents")
 std::string toUpperString(std::string const& s)
 {
     std::string upperString;
-    std::locale loc;
-    std::transform(begin(s), end(s), pipes::push_back(upperString), [&loc](char c){ return static_cast<char>(std::toupper(c, loc)); });
+    std::transform(begin(s), end(s), pipes::push_back(upperString), [](char c){ return static_cast<char>(std::toupper(c)); });
     return upperString;
 }
 


### PR DESCRIPTION
Visual C++ compiler needs the <cctype> include. Seems to be a speciality, but also has no bad impact on gcc.

Fixes #44 