### PR TITLE
Add macro to use std::optional (and other types) in C++17 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ dist: bionic
 
 matrix:
     include:
+    - env: CXX=g++-10 CC=gcc-10
+      addons:
+        apt:
+          packages:
+            - g++-10
+          sources:
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
     - env: CXX=g++-9 CC=gcc-9
       addons:
         apt:

--- a/include/pipes/helpers/optional.hpp
+++ b/include/pipes/helpers/optional.hpp
@@ -1,12 +1,20 @@
 #ifndef PIPES_OPTIONAL_HPP
 #define PIPES_OPTIONAL_HPP
 
+#include <utility>
 #include <type_traits>
 
 namespace pipes
 {
 namespace detail
 {
+#if __cplusplus >= 201703L
+    using nullopt_t = std::nullopt_t;
+    static const nullopt_t nullopt = std::nullopt;
+
+    template <typename T>
+    using optional = std::optional<T>;
+#else
     struct nullopt_t {};
     static const nullopt_t nullopt;
 
@@ -47,6 +55,7 @@ namespace detail
         std::aligned_storage_t<sizeof(T)> m_object;
         bool m_initialized;
     };
+#endif /* #if __cplusplus == 201703L */
 
 } // namespace detail
 } // namespace pipes


### PR DESCRIPTION
- Added `#if __cplusplus >= 201703L` to `pipes/helpers/optional.hpp`
- Added `#include <utility>` as well because `std::forward` is not guaranteed to exist
  without this include preprocessor
- Added GCC10 to `.travis.yml`

All tests were successful (in GCC 10, WSL2 Arch Linux environment)