### PR TITLE
Add move only type support.

### DIFF
--- a/include/pipes/operator.hpp
+++ b/include/pipes/operator.hpp
@@ -9,13 +9,23 @@
 namespace pipes
 {
 
-// range >>= pipeline
+// range >>= pipeline (rvalue ranges)
     
     template<typename Range, typename Pipeline, detail::IsARange<Range> = true, detail::IsAPipeline<Pipeline> = true>
-    void operator>>=(Range&& range, Pipeline&& pipeline)
+    std::enable_if_t<!std::is_lvalue_reference<Range>::value> operator>>=(Range&& range, Pipeline&& pipeline)
     {
-	using std::begin;
-	using std::end;
+        using std::begin;
+        using std::end;
+        std::copy(std::make_move_iterator(begin(range)), std::make_move_iterator(end(range)), pipeline);
+    }
+
+// range >>= pipeline (lvalue ranges)
+    
+    template<typename Range, typename Pipeline, detail::IsARange<Range> = true, detail::IsAPipeline<Pipeline> = true>
+    std::enable_if_t<std::is_lvalue_reference<Range>::value> operator>>=(Range&& range, Pipeline&& pipeline)
+    {
+        using std::begin;
+        using std::end;
         std::copy(begin(range), end(range), pipeline);
     }
 


### PR DESCRIPTION
This adds support for moving ranges into a pipe by overloading the operator>>= for rvalue and lvalue ranges.

Not the most useful code, but this compiles and proves the framework plumbs everything through properly.
```
std::vector<std::unique_ptr<int>> input;
std::vector<std::unique_ptr<int>> result;

std::move(input) >>= pipes::transform([](auto&& ptr) -> decltype(auto) { return std::move(ptr); })
                 >>= pipes::push_back(result);
```

I wasn't sure the best way to test this, at a high level it seems to be a test of the internals instead of a specific pipe. To start I just added a simple test that a unique_ptr can flow through a transform pipe.