### PR TITLE
fixed problem related to compiling with MSVC with language version c++20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .DS_Store
 build/
 install/
+
+.vs

--- a/include/pipes/helpers/invoke.hpp
+++ b/include/pipes/helpers/invoke.hpp
@@ -8,23 +8,46 @@ namespace pipes
 {
     namespace detail
     {
+#ifdef _MSC_VER
+#if _MSVC_LANG >  201703L
         template<typename Functor, typename... Args>
         typename std::enable_if<
-        std::is_member_pointer<typename std::decay<Functor>::type>::value,
-        typename std::result_of<Functor&&(Args&&...)>::type
+            std::is_member_pointer<typename std::decay<Functor>::type>::value,
+            typename std::invoke_result<Functor && (Args&&...)>::type
         >::type invoke(Functor&& f, Args&&... args)
         {
             return std::mem_fn(f)(std::forward<Args>(args)...);
         }
-        
+
         template<typename Functor, typename... Args>
         typename std::enable_if<
-        !std::is_member_pointer<typename std::decay<Functor>::type>::value,
-        typename std::result_of<Functor&&(Args&&...)>::type
+            !std::is_member_pointer<typename std::decay<Functor>::type>::value,
+            typename std::invoke_result<Functor && (Args&&...)>::type
         >::type invoke(Functor&& f, Args&&... args)
         {
             return std::forward<Functor>(f)(std::forward<Args>(args)...);
         }
+#else
+        template<typename Functor, typename... Args>
+        typename std::enable_if<
+            std::is_member_pointer<typename std::decay<Functor>::type>::value,
+            typename std::result_of<Functor && (Args&&...)>::type
+        >::type invoke(Functor&& f, Args&&... args)
+        {
+            return std::mem_fn(f)(std::forward<Args>(args)...);
+        }
+
+        template<typename Functor, typename... Args>
+        typename std::enable_if<
+            !std::is_member_pointer<typename std::decay<Functor>::type>::value,
+            typename std::result_of<Functor && (Args&&...)>::type
+        >::type invoke(Functor&& f, Args&&... args)
+        {
+            return std::forward<Functor>(f)(std::forward<Args>(args)...);
+        }
+#endif
+#endif
+
     }
 }
 


### PR DESCRIPTION
Usage of std::invoke_result instead of std::result_of, as std::result_of was removed from the MSVC's standard library.