### PR TITLE
[hotfix] Include optional header to fix import errors

### DIFF
--- a/include/pipes/helpers/optional.hpp
+++ b/include/pipes/helpers/optional.hpp
@@ -2,6 +2,9 @@
 #define PIPES_OPTIONAL_HPP
 
 #include <type_traits>
+#if __cplusplus >= 201703L
+#  include <optional>
+#endif
 
 namespace pipes
 {


### PR DESCRIPTION
Hello!

When consuming Pipes headers with a newer compiler that supports C++17 and has std::optional too, the header `pipes/helpers/optional.hpp` consumes `std::nullopt_t` and `std::optional<T>`, but it's not included, resulting the error when building.

This error is pointed by the issue #64, but there is solution so far. Please, consider this PR as a hotfix.

The consumer should not manage it, as it's direct dependency from Pipes and follows a good design pointed by "Include What You Use" (https://www.fluentcpp.com/2021/01/01/include-what-you-use/)

The failed build log as reference:

```
Run Build Command(s): /usr/bin/ninja -v -j12
[1/2] /usr/bin/c++  -isystem /home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include -m64 -O3 -DNDEBUG -std=gnu++17 -MD -MT CMakeFiles/test_package.dir/test_package.cpp.o -MF CMakeFiles/test_package.dir/test_package.cpp.o.d -o CMakeFiles/test_package.dir/test_package.cpp.o -c /home/uilian/Development/conan/conan-center-index/recipes/pipes/all/test_package/test_package.cpp
FAILED: CMakeFiles/test_package.dir/test_package.cpp.o 
/usr/bin/c++  -isystem /home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include -m64 -O3 -DNDEBUG -std=gnu++17 -MD -MT CMakeFiles/test_package.dir/test_package.cpp.o -MF CMakeFiles/test_package.dir/test_package.cpp.o.d -o CMakeFiles/test_package.dir/test_package.cpp.o -c /home/uilian/Development/conan/conan-center-index/recipes/pipes/all/test_package/test_package.cpp
In file included from /home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/assignable.hpp:4,
                 from /home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/drop_while.hpp:5,
                 from /home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/pipes.hpp:10,
                 from /home/uilian/Development/conan/conan-center-index/recipes/pipes/all/test_package/test_package.cpp:11:
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/optional.hpp:12:28: error: ‘nullopt_t’ in namespace ‘std’ does not name a type; did you mean ‘nullptr_t’?
   12 |     using nullopt_t = std::nullopt_t;
      |                            ^~~~~~~~~
      |                            nullptr_t
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/optional.hpp:13:18: error: ‘nullopt_t’ does not name a type; did you mean ‘nullptr_t’?
   13 |     static const nullopt_t nullopt = std::nullopt;
      |                  ^~~~~~~~~
      |                  nullptr_t
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/optional.hpp:16:27: error: ‘optional’ in namespace ‘std’ does not name a template type
   16 |     using optional = std::optional<T>;
      |                           ^~~~~~~~
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/optional.hpp:1:1: note: ‘std::optional’ is defined in header ‘<optional>’; did you forget to ‘#include <optional>’?
  +++ |+#include <optional>
    1 | #ifndef PIPES_OPTIONAL_HPP
In file included from /home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/drop_while.hpp:5,
                 from /home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/pipes.hpp:10,
                 from /home/uilian/Development/conan/conan-center-index/recipes/pipes/all/test_package/test_package.cpp:11:
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/assignable.hpp:42:5: error: ‘optional’ does not name a type
   42 |     optional<T> value_;
      |     ^~~~~~~~
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/assignable.hpp: In member function ‘pipes::detail::assignable<T>& pipes::detail::assignable<T>::operator=(const pipes::detail::assignable<T>&)’:
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/assignable.hpp:18:9: error: ‘value_’ was not declared in this scope
   18 |         value_.emplace(*other.value_);
      |         ^~~~~~
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/assignable.hpp: In member function ‘pipes::detail::assignable<T>& pipes::detail::assignable<T>::operator=(pipes::detail::assignable<T>&&)’:
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/assignable.hpp:23:9: error: ‘value_’ was not declared in this scope
   23 |         value_ = std::move(other.value_);
      |         ^~~~~~
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/assignable.hpp: In copy constructor ‘pipes::detail::assignable<T>::assignable(const pipes::detail::assignable<T>&)’:
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/assignable.hpp:26:43: error: class ‘pipes::detail::assignable<T>’ does not have any field named ‘value_’
   26 |     assignable(assignable const& other) : value_(other.value_){}
      |                                           ^~~~~~
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/assignable.hpp: In constructor ‘pipes::detail::assignable<T>::assignable(pipes::detail::assignable<T>&&)’:
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/assignable.hpp:28:38: error: class ‘pipes::detail::assignable<T>’ does not have any field named ‘value_’
   28 |     assignable(assignable&& other) : value_(std::move(other.value_)) {}
      |                                      ^~~~~~
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/assignable.hpp: In constructor ‘pipes::detail::assignable<T>::assignable(const T&)’:
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/assignable.hpp:30:34: error: class ‘pipes::detail::assignable<T>’ does not have any field named ‘value_’
   30 |     assignable(T const& value) : value_(value) {}
      |                                  ^~~~~~
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/assignable.hpp: In constructor ‘pipes::detail::assignable<T>::assignable(T&&)’:
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/assignable.hpp:31:29: error: class ‘pipes::detail::assignable<T>’ does not have any field named ‘value_’
   31 |     assignable(T&& value) : value_(std::move(value)) {}
      |                             ^~~~~~
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/assignable.hpp: In member function ‘const T& pipes::detail::assignable<T>::get() const’:
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/assignable.hpp:33:36: error: ‘value_’ was not declared in this scope
   33 |     T const& get() const { return *value_; }
      |                                    ^~~~~~
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/assignable.hpp: In member function ‘T& pipes::detail::assignable<T>::get()’:
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/assignable.hpp:34:24: error: ‘value_’ was not declared in this scope
   34 |     T& get() { return *value_; }
      |                        ^~~~~~
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/assignable.hpp: In member function ‘decltype(auto) pipes::detail::assignable<T>::operator()(Args&& ...)’:
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/helpers/assignable.hpp:39:18: error: ‘value_’ was not declared in this scope
   39 |         return (*value_)(std::forward<Args>(args)...);
      |                  ^~~~~~
In file included from /home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/pipes.hpp:15,
                 from /home/uilian/Development/conan/conan-center-index/recipes/pipes/all/test_package/test_package.cpp:11:
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/insert.hpp: At global scope:
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/insert.hpp:41:13: error: ‘optional’ in namespace ‘pipes::detail’ does not name a template type
   41 |     detail::optional<typename Container::iterator> hint_;
      |             ^~~~~~~~
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/insert.hpp: In member function ‘void pipes::insert_iterator_with_no_position<Container>::onReceive(T&&)’:
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/insert.hpp:30:13: error: ‘hint_’ was not declared in this scope; did you mean ‘wint_t’?
   30 |         if (hint_)
      |             ^~~~~
      |             wint_t
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/insert.hpp: In constructor ‘pipes::insert_iterator_with_no_position<Container>::insert_iterator_with_no_position(Container&)’:
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/insert.hpp:36:96: error: class ‘pipes::insert_iterator_with_no_position<Container>’ does not have any field named ‘hint_’
   36 |     explicit insert_iterator_with_no_position (Container& container) : container_(&container), hint_(detail::nullopt) {}
      |                                                                                                ^~~~~
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/insert.hpp:36:110: error: ‘nullopt’ is not a member of ‘pipes::detail’
   36 |     explicit insert_iterator_with_no_position (Container& container) : container_(&container), hint_(detail::nullopt) {}
      |                                                                                                              ^~~~~~~
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/insert.hpp: In constructor ‘pipes::insert_iterator_with_no_position<Container>::insert_iterator_with_no_position(Container&, typename Container::iterator)’:
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/insert.hpp:37:122: error: class ‘pipes::insert_iterator_with_no_position<Container>’ does not have any field named ‘hint_’
   37 |     insert_iterator_with_no_position (Container& container, typename Container::iterator hint) : container_(&container), hint_(hint) {}
      |                                                                                                                          ^~~~~
In file included from /home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/pipes.hpp:11,
                 from /home/uilian/Development/conan/conan-center-index/recipes/pipes/all/test_package/test_package.cpp:11:
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/filter.hpp: In instantiation of ‘void pipes::filter_pipe<Predicate>::onReceive(Values&& ..., TailPipeline&&) [with Values = {int&}; TailPipeline = pipes::detail::generic_pipeline<pipes::transform_pipe<main()::<lambda(int)> >, pipes::push_back_pipeline<std::vector<int> > >&; Predicate = main()::<lambda(int)>]’:
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/impl/pipes_assembly.hpp:18:52:   required from ‘void pipes::detail::generic_pipeline<HeadPipe, TailPipeline>::onReceive(Ts&& ...) [with Ts = {int&}; HeadPipe = pipes::filter_pipe<main()::<lambda(int)> >; TailPipeline = pipes::detail::generic_pipeline<pipes::transform_pipe<main()::<lambda(int)> >, pipes::push_back_pipeline<std::vector<int> > >]’
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/send.hpp:32:27:   required from ‘void pipes::send(T&&, Pipeline&) [with T = int&; Pipeline = pipes::detail::generic_pipeline<pipes::filter_pipe<main()::<lambda(int)> >, pipes::detail::generic_pipeline<pipes::transform_pipe<main()::<lambda(int)> >, pipes::push_back_pipeline<std::vector<int> > > >]’
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/base.hpp:21:17:   required from ‘pipes::pipeline_proxy<Pipeline>& pipes::pipeline_proxy<Pipeline>::operator=(T&&) [with T = int&; Pipeline = pipes::detail::generic_pipeline<pipes::filter_pipe<main()::<lambda(int)> >, pipes::detail::generic_pipeline<pipes::transform_pipe<main()::<lambda(int)> >, pipes::push_back_pipeline<std::vector<int> > > >]’
/usr/include/c++/11/bits/stl_algobase.h:385:18:   required from ‘static _OI std::__copy_move<false, false, std::random_access_iterator_tag>::__copy_m(_II, _II, _OI) [with _II = int*; _OI = pipes::detail::generic_pipeline<pipes::filter_pipe<main()::<lambda(int)> >, pipes::detail::generic_pipeline<pipes::transform_pipe<main()::<lambda(int)> >, pipes::push_back_pipeline<std::vector<int> > > >]’
/usr/include/c++/11/bits/stl_algobase.h:495:30:   required from ‘_OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = false; _II = int*; _OI = pipes::detail::generic_pipeline<pipes::filter_pipe<main()::<lambda(int)> >, pipes::detail::generic_pipeline<pipes::transform_pipe<main()::<lambda(int)> >, pipes::push_back_pipeline<std::vector<int> > > >]’
/usr/include/c++/11/bits/stl_algobase.h:522:42:   required from ‘_OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = false; _II = int*; _OI = pipes::detail::generic_pipeline<pipes::filter_pipe<main()::<lambda(int)> >, pipes::detail::generic_pipeline<pipes::transform_pipe<main()::<lambda(int)> >, pipes::push_back_pipeline<std::vector<int> > > >]’
/usr/include/c++/11/bits/stl_algobase.h:530:31:   required from ‘_OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = __gnu_cxx::__normal_iterator<int*, std::vector<int> >; _OI = pipes::detail::generic_pipeline<pipes::filter_pipe<main()::<lambda(int)> >, pipes::detail::generic_pipeline<pipes::transform_pipe<main()::<lambda(int)> >, pipes::push_back_pipeline<std::vector<int> > > >]’
/usr/include/c++/11/bits/stl_algobase.h:620:7:   required from ‘_OI std::copy(_II, _II, _OI) [with _II = __gnu_cxx::__normal_iterator<int*, std::vector<int> >; _OI = pipes::detail::generic_pipeline<pipes::filter_pipe<main()::<lambda(int)> >, pipes::detail::generic_pipeline<pipes::transform_pipe<main()::<lambda(int)> >, pipes::push_back_pipeline<std::vector<int> > > >]’
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/operator.hpp:23:18:   required from ‘void pipes::operator>>=(Range&&, Pipeline&&) [with Range = std::vector<int>&; Pipeline = pipes::detail::generic_pipeline<pipes::filter_pipe<main()::<lambda(int)> >, pipes::detail::generic_pipeline<pipes::transform_pipe<main()::<lambda(int)> >, pipes::push_back_pipeline<std::vector<int> > > >; typename std::enable_if<range_expression_detected<typename std::remove_reference<_Tp>::type>, bool>::type <anonymous> = true; typename std::enable_if<std::is_base_of<pipes::pipeline_base<typename std::remove_reference<_Arg>::type>, typename std::remove_reference<_Arg>::type>::value, bool>::type <anonymous> = true]’
/home/uilian/Development/conan/conan-center-index/recipes/pipes/all/test_package/test_package.cpp:20:41:   required from here
/home/uilian/.conan2/p/b/pipes4d32270f84dd7/p/include/pipes/filter.hpp:19:27: error: could not convert ‘((pipes::filter_pipe<main()::<lambda(int)> >*)this)->pipes::filter_pipe<main()::<lambda(int)> >::predicate_.pipes::detail::assignable<main()::<lambda(int)> >::operator()<int&>((* & values#0))’ from ‘void’ to ‘bool’
   19 |             if (predicate_(values...))
      |                 ~~~~~~~~~~^~~~~~~~~~~
      |                           |
      |                           void
ninja: build stopped: subcommand failed.
```

### Environment

* OS: Linux 6.8
* Distro: Ubuntu 22.04
* Compiler: GCC 11.4.0
* CPU: Intel x86_64
* CMake: 3.30.3
* Ninja: 1.10.1


fixes #64